### PR TITLE
Generate manifest file after localizetext process is done

### DIFF
--- a/AppinfoJsonFile.js
+++ b/AppinfoJsonFile.js
@@ -321,6 +321,8 @@ AppinfoJsonFile.prototype.writeManifest = function(filePath) {
         files: []
     };
 
+    if (!fs.existsSync(filePath)) return;
+
     function walk(root, dir) {
         var list = fs.readdirSync(path.join(root, dir));
         list.forEach(function (file) {

--- a/AppinfoJsonFile.js
+++ b/AppinfoJsonFile.js
@@ -318,6 +318,31 @@ AppinfoJsonFile.prototype.localize = function(translations, locales) {
   */
 AppinfoJsonFile.prototype.writeManifest = function(filePath, manifestInfo) {
     console.log("#### AppinfoJsonFile: writeManifest");
+    var manifest = {
+        files: []
+    };
+
+    function walk(root, dir) {
+        var list = fs.readdirSync(path.join(root, dir));
+        list.forEach(function (file) {
+            var sourcePathRelative = path.join(dir, file);
+            var sourcePath = path.join(root, sourcePathRelative);
+            var stat = fs.statSync(sourcePath);
+            if (stat && stat.isDirectory()) {
+                walk(root, sourcePathRelative);
+            } else {
+                if (file.match(/\.json$/) && (file !== "ilibmanifest.json")) {
+                    manifest.files.push(sourcePathRelative);
+                }
+            }
+        });
+    }
+
+    walk(filePath, "");
+    for (var i=0; i < manifest.files.length; i++) {
+        console.log("list: ", manifest.files[i]);
+    }
+
 }
 
 module.exports = AppinfoJsonFile;

--- a/AppinfoJsonFile.js
+++ b/AppinfoJsonFile.js
@@ -313,4 +313,11 @@ AppinfoJsonFile.prototype.localize = function(translations, locales) {
     }
 };
 
+/**
+  * Write the manifest file to dist.
+  */
+AppinfoJsonFile.prototype.writeManifest = function(filePath, manifestInfo) {
+    console.log("#### AppinfoJsonFile: writeManifest");
+}
+
 module.exports = AppinfoJsonFile;

--- a/AppinfoJsonFile.js
+++ b/AppinfoJsonFile.js
@@ -317,7 +317,6 @@ AppinfoJsonFile.prototype.localize = function(translations, locales) {
   * Write the manifest file to dist.
   */
 AppinfoJsonFile.prototype.writeManifest = function(filePath) {
-    console.log("#### AppinfoJsonFile: writeManifest");
     var manifest = {
         files: []
     };
@@ -340,7 +339,7 @@ AppinfoJsonFile.prototype.writeManifest = function(filePath) {
 
     walk(filePath, "");
     for (var i=0; i < manifest.files.length; i++) {
-        console.log("list: ", manifest.files[i]);
+        logger.info("Generated resource list " + manifest.files[i]);
     }
     var manifestFilePath = path.join(filePath, "ilibmanifest.json");
     fs.writeFileSync(manifestFilePath, JSON.stringify(manifest), 'utf8');

--- a/AppinfoJsonFile.js
+++ b/AppinfoJsonFile.js
@@ -316,7 +316,7 @@ AppinfoJsonFile.prototype.localize = function(translations, locales) {
 /**
   * Write the manifest file to dist.
   */
-AppinfoJsonFile.prototype.writeManifest = function(filePath, manifestInfo) {
+AppinfoJsonFile.prototype.writeManifest = function(filePath) {
     console.log("#### AppinfoJsonFile: writeManifest");
     var manifest = {
         files: []
@@ -342,7 +342,8 @@ AppinfoJsonFile.prototype.writeManifest = function(filePath, manifestInfo) {
     for (var i=0; i < manifest.files.length; i++) {
         console.log("list: ", manifest.files[i]);
     }
-
+    var manifestFilePath = path.join(filePath, "ilibmanifest.json");
+    fs.writeFileSync(manifestFilePath, JSON.stringify(manifest), 'utf8');
 }
 
 module.exports = AppinfoJsonFile;

--- a/AppinfoJsonFileType.js
+++ b/AppinfoJsonFileType.js
@@ -150,4 +150,29 @@ AppinfoJsonFileType.prototype.getExtensions = function() {
     return this.extensions;
 };
 
+/**
+  * Called right before each project is closed
+  * Allows the file type class to do any last-minute clean-up or generate any final files
+  *
+  * Generate manifest file based on created resource files
+  */
+AppinfoJsonFileType.prototype.projectClose = function() {
+    var resourceRoot = this.project.getResourceDirs("json")[0] || "resources";
+    var resourcePathList = [], localizePath;
+    var targetLocales = this.project.locales;
+
+    for (var i=0; i < targetLocales.length; i++) {
+        var manifestFile = new AppinfoJsonFile({
+            project: this.project,
+            type: this.type,
+            locale: targetLocales[i]
+        })
+        console.log("manifestFile Path: ", manifestFile.getLocalizedPath(targetLocales[i]));
+        localizePath = manifestFile.getLocalizedPath(targetLocales[i]).replace(resourceRoot + "/","");
+        resourcePathList.push(localizePath + "/appinfo.json");
+    }
+
+    manifestFile.writeManifest(resourceRoot, resourcePathList);
+};
+
 module.exports = AppinfoJsonFileType;

--- a/AppinfoJsonFileType.js
+++ b/AppinfoJsonFileType.js
@@ -158,21 +158,11 @@ AppinfoJsonFileType.prototype.getExtensions = function() {
   */
 AppinfoJsonFileType.prototype.projectClose = function() {
     var resourceRoot = this.project.getResourceDirs("json")[0] || "resources";
-    var resourcePathList = [], localizePath;
-    var targetLocales = this.project.locales;
-
-    for (var i=0; i < targetLocales.length; i++) {
-        var manifestFile = new AppinfoJsonFile({
+    var manifestFile = new AppinfoJsonFile({
             project: this.project,
-            type: this.type,
-            locale: targetLocales[i]
-        })
-        console.log("manifestFile Path: ", manifestFile.getLocalizedPath(targetLocales[i]));
-        localizePath = manifestFile.getLocalizedPath(targetLocales[i]).replace(resourceRoot + "/","");
-        resourcePathList.push(localizePath + "/appinfo.json");
-    }
-
-    manifestFile.writeManifest(resourceRoot, resourcePathList);
+            type: this.type
+        });
+    manifestFile.writeManifest(resourceRoot);
 };
 
 module.exports = AppinfoJsonFileType;

--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ allows it to read and localize `appinfo.json` file. This plugin is optimized for
 v1.0.0
 * Implemented `appinfo.json` file localization. The appinfo.json file resides in an app's root directory and contains a single JSON object. Some Some properties data in a JSON object need to be localized, such as `title`. It is defined in the schema file. If you want to get more information regarding `appinfo.json` on webOS, Please visit this [link](https://www.webosose.org/docs/guides/development/configuration-files/appinfo-json/).
 
+v1.1.0
+* Add feature to generate `ilibmanifest.json` file
+
 ## License
 
 Copyright © 2019, JEDLSoft

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ v1.0.0
 * Implemented `appinfo.json` file localization. The appinfo.json file resides in an app's root directory and contains a single JSON object. Some Some properties data in a JSON object need to be localized, such as `title`. It is defined in the schema file. If you want to get more information regarding `appinfo.json` on webOS, Please visit this [link](https://www.webosose.org/docs/guides/development/configuration-files/appinfo-json/).
 
 v1.1.0
-* Add feature to generate `ilibmanifest.json` file
+* Added feature to generate `ilibmanifest.json` file
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-webos-appinfo-json",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "main": "AppinfoJsonFileType.js",
     "description": "appinfo.json file handler plugin for webOS platform loctool",
     "license": "Apache-2.0",


### PR DESCRIPTION
Added feature to generate `ilibmanifest.json` file after localize process is done.
It scans the resource output directory then added a file list to the manifest file.