### PR TITLE
Fix code to search javascript group only in xliff file

### DIFF
--- a/AppinfoJsonFile.js
+++ b/AppinfoJsonFile.js
@@ -47,15 +47,7 @@ var AppinfoJsonFile = function(props) {
     this.baseLocale = langDefaultLocale.getLikelyLocaleMinimal().getSpec() === this.locale.getSpec();
     this.type = props.type;
 
-    // datatype value is using to create reskey
-    var dataTypeMap = {
-        "webos-web":"javascript",
-        "webos-qml": "x-qml",
-        "webos-cpp": "cpp",
-        "webos-c": "cpp"
-    }
-
-    this.datatype = dataTypeMap[this.project.options.projectType] || "javascript";
+    this.datatype = "javascript";
     this.set = this.API.newTranslationSet(this.project ? this.project.sourceLocale : "zxx-XX");
 };
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ ilib-loctool-webos-appinfo-json is a plugin for the loctool that
 allows it to read and localize `appinfo.json` file. This plugin is optimized for webOS platform
 
 ## Release Notes
+v1.2.0
+* Fix code to search javascript group only in xliff file
+
 v1.1.0
 * Added feature to generate `ilibmanifest.json` file
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-webos-appinfo-json",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "main": "AppinfoJsonFileType.js",
     "description": "appinfo.json file handler plugin for webOS platform loctool",
     "license": "Apache-2.0",


### PR DESCRIPTION
* When searching translation values, webOS always search `javascript` group tag only in cliff file no matter what app type is. If it doesn't exist, it just passes. That's the current implementation so far.