### PR TITLE
Define x-json type which will search first to get a translation.

### DIFF
--- a/AppinfoJsonFile.js
+++ b/AppinfoJsonFile.js
@@ -174,7 +174,7 @@ AppinfoJsonFile.prototype.parse = function(data) {
             });
             this.set.add(r);
         } else {
-            logger.warn("This property doesn't have localized `true` or not match the required data type:  ", property);
+            logger.debug("[" + property + "] property doesn't have localized `true` or not match the required data type.");
         }
     }
 };
@@ -344,4 +344,3 @@ AppinfoJsonFile.prototype.writeManifest = function(filePath) {
 }
 
 module.exports = AppinfoJsonFile;
-

--- a/AppinfoJsonFile.js
+++ b/AppinfoJsonFile.js
@@ -47,7 +47,7 @@ var AppinfoJsonFile = function(props) {
     this.baseLocale = langDefaultLocale.getLikelyLocaleMinimal().getSpec() === this.locale.getSpec();
     this.type = props.type;
 
-    this.datatype = "javascript";
+    this.datatype = "x-json";
     this.set = this.API.newTranslationSet(this.project ? this.project.sourceLocale : "zxx-XX");
 };
 
@@ -252,10 +252,12 @@ AppinfoJsonFile.prototype.localizeText = function(translations, locale) {
                 project: this.project.getProjectId(),
                 sourceLocale: this.project.getSourceLocale(),
                 reskey: key,
-                datatype: this.datatype || "javascript"
+                datatype: this.datatype
             });
             var hashkey = tester.hashKeyForTranslation(locale);
-            var translated = translations.getClean(hashkey);
+            var alternativeKey = hashkey.replace("x-json", "javascript");
+
+            var translated = translations.getClean(hashkey) || translations.getClean(alternativeKey);
 
             if (translated) {
                 output[property] = translated.target;
@@ -271,7 +273,7 @@ AppinfoJsonFile.prototype.localizeText = function(translations, locale) {
                     target: this.API.utils.escapeInvalidChars(text),
                     reskey: key,
                     state: "new",
-                    datatype: this.datatype || "javascript"
+                    datatype: this.datatype
                 });
                 this.type.newres.add(r);
             }
@@ -299,8 +301,10 @@ AppinfoJsonFile.prototype.localize = function(translations, locales) {
        if (!this.project.isSourceLocale(locales[i])) {
             var pathName = this.getLocalizedPath(locales[i]);
             var translatedOutput = this.localizeText(translations, locales[i]);
-            this.API.utils.makeDirs(pathName);
-            fs.writeFileSync(pathName + "/appinfo.json", translatedOutput, "utf-8");
+            if (translatedOutput !== "{}") {
+                this.API.utils.makeDirs(pathName);
+                fs.writeFileSync(pathName + "/appinfo.json", translatedOutput, "utf-8");
+            }
        }
     }
 };

--- a/AppinfoJsonFileType.js
+++ b/AppinfoJsonFileType.js
@@ -28,18 +28,7 @@ var AppinfoJsonFileType = function(project) {
     this.resourceType = "json";
     this.project = project;
     this.extensions = [".json"];
-
-    /* in order to match proper xliff
-    * datatype value is using to create reskey
-    */
-    var dataTypeMap = {
-        "webos-web":"javascript",
-        "webos-qml": "x-qml",
-        "webos-cpp": "cpp",
-        "webos-c": "cpp"
-    }
-
-    this.datatype = dataTypeMap[project.options.projectType] || "javascript";
+    this.datatype = "x-json";
 
     this.API = project.getAPI();
     this.extracted = this.API.newTranslationSet(project.getSourceLocale());

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ allows it to read and localize `appinfo.json` file. This plugin is optimized for
 
 ## Release Notes
 v1.2.0
-* Fix code to search javascript group only in xliff file
+* Create `x-json` type which will search first to get a translation. If it doesn't exist, it will search the `javascript` group tag as an alternative.
+* Fix not to create a file if there is no translation data.
 
 v1.1.0
 * Added feature to generate `ilibmanifest.json` file

--- a/test/testAppinfoJsonFile.js
+++ b/test/testAppinfoJsonFile.js
@@ -337,6 +337,105 @@ module.exports.appinfojsonfile = {
         test.equal(actual, expected);
         test.done();
     },
+    testAppinfoJsonLocalzeTextxJsonKey: function(test) {
+        test.expect(2);
+        var ajf = new AppinfoJsonFile({
+            project: p,
+            type: ajft
+        });
+        test.ok(ajf);
+        ajf.parse({
+            "id": "app",
+            "title": "Photo &amp; Video",
+            "version": "4.0.1",
+            "type": "webos-web",
+            "usePrerendering": true,
+            "v8SnapshotFile": "snapshot_b"
+        });
+        var translations = new TranslationSet();
+        var resource = new ResourceString({
+            project: "app",
+            source: "Photo &amp; Video",
+            sourceLocale: "en-US",
+            key: "Photo &amp; Video",
+            target: "사진 &amp; 동영상",
+            targetLocale: "ko-KR",
+            datatype: "x-json"
+        })
+        translations.add(resource);
+
+        var actual = ajf.localizeText(translations, "ko-KR");
+        var expected = '{\n    "title": "사진 &amp; 동영상"\n}';
+        test.equal(actual, expected);
+        test.done();
+    },
+    testAppinfoJsonLocalzeTextxJsonKey2: function(test) {
+        test.expect(2);
+        var ajf = new AppinfoJsonFile({
+            project: p,
+            type: ajft
+        });
+        test.ok(ajf);
+        ajf.parse({
+            "id": "app",
+            "title": "Photo &amp; Video",
+        });
+        var translations = new TranslationSet();
+        var resource = new ResourceString({
+            project: "app",
+            source: "Photo &amp; Video",
+            sourceLocale: "en-US",
+            key: "Photo &amp; Video",
+            target: "사진 &amp; 동영상",
+            targetLocale: "ko-KR",
+            datatype: "x-json"
+        })
+        translations.add(resource);
+
+        var resource2 = new ResourceString({
+            project: "app",
+            source: "Photo &amp; Video",
+            sourceLocale: "en-US",
+            key: "Photo &amp; Video",
+            target: "사진 &amp; 동영상2",
+            targetLocale: "ko-KR",
+            datatype: "javascript"
+        })
+        translations.add(resource2);
+
+        var actual = ajf.localizeText(translations, "ko-KR");
+        var expected = '{\n    "title": "사진 &amp; 동영상"\n}';
+        test.equal(actual, expected);
+        test.done();
+    },
+    testAppinfoJsonLocalzeTextxJsonKey3: function(test) {
+        test.expect(2);
+        var ajf = new AppinfoJsonFile({
+            project: p,
+            type: ajft
+        });
+        test.ok(ajf);
+        ajf.parse({
+            "id": "app",
+            "title": "Photo &amp; Video",
+        });
+        var translations = new TranslationSet();
+        var resource2 = new ResourceString({
+            project: "app",
+            source: "Photo &amp; Video",
+            sourceLocale: "en-US",
+            key: "Photo &amp; Video",
+            target: "사진 &amp; 동영상2",
+            targetLocale: "ko-KR",
+            datatype: "javascript"
+        })
+        translations.add(resource2);
+
+        var actual = ajf.localizeText(translations, "ko-KR");
+        var expected = '{\n    "title": "사진 &amp; 동영상2"\n}';
+        test.equal(actual, expected);
+        test.done();
+    },
     testAppinfoJsonLocalzeTextMultiple: function(test) {
         test.expect(2);
         var ajf = new AppinfoJsonFile({
@@ -373,7 +472,7 @@ module.exports.appinfojsonfile = {
             key: "Photo &amp; Video@oled",
             target: "사진 &amp; 동영상",
             targetLocale: "ko-KR",
-            datatype: "javascript"
+            datatype: "x-json"
         }));
 
         var actual = ajf.localizeText(translations, "ko-KR");


### PR DESCRIPTION
* Defined x-json type as default datatype in this plugin. data type name `x-json` is using when making a hashkey). so It will search for a translation by key x-json datatype first and if it doesn't exist, it checks data key with javascript.
* It solves a problem when two plugins use different resource type each
  Issue case) Currently, `ilib-loctool-webos-qml` plugin uses `ContextResourceString`, and `ilib-loctool-webos-appinfo-json` plugin uses `ResourceString` type. I've found an issue when the project initializes step, the qml plugins resource type is overwritten as ResourceString. 
* Additionally fixed not to create a file if there is no translation data.