### PR TITLE
Fixed to load schema file correctly wherever plugin is installed

### DIFF
--- a/AppinfoJsonFile.js
+++ b/AppinfoJsonFile.js
@@ -114,11 +114,12 @@ AppinfoJsonFile.prototype.makeKey = function(source) {
 };
 
 AppinfoJsonFile.prototype.loadSchema = function(source) {
-    var localizeProperties = {}, schemaFilePath;
+    var localizeProperties = {}, schemaFilePath, modulePath;
     if (this.project.schema) {
         schemaFilePath = path.join(process.env.PWD, this.project.schema);
     } else {
-        schemaFilePath = path.join(process.env.PWD, "node_modules", "ilib-loctool-webos-appinfo-json", "schema/appinfo.schema.json");
+        modulePath = path.join(require.resolve("ilib-loctool-webos-appinfo-json"), "../");
+        schemaFilePath = path.join(modulePath, "schema/appinfo.schema.json");
     }
     logger.debug("AppinfoJsonFileTyp load Schema File " + schemaFilePath + "?");
     var loadSchemaFile, schemaData;
@@ -244,7 +245,7 @@ AppinfoJsonFile.prototype.localizeText = function(translations, locale) {
     var output = {};
     var stringifyOuput ="";
     for (var property in this.parsedData) {
-        if (this.schema[property]){
+        if (this.schema && this.schema[property]){
             var text = this.parsedData[property];
             var key = this.makeKey(this.API.utils.escapeInvalidChars(text));
             var tester = this.API.newResource({

--- a/AppinfoJsonFile.js
+++ b/AppinfoJsonFile.js
@@ -114,12 +114,11 @@ AppinfoJsonFile.prototype.makeKey = function(source) {
 };
 
 AppinfoJsonFile.prototype.loadSchema = function(source) {
-    var localizeProperties = {}, schemaFilePath, modulePath;
+    var localizeProperties = {}, schemaFilePath;
     if (this.project.schema) {
         schemaFilePath = path.join(process.env.PWD, this.project.schema);
     } else {
-        modulePath = path.join(require.resolve("ilib-loctool-webos-appinfo-json"), "../");
-        schemaFilePath = path.join(modulePath, "schema/appinfo.schema.json");
+        schemaFilePath = path.join(__dirname, "schema/appinfo.schema.json");
     }
     logger.debug("AppinfoJsonFileTyp load Schema File " + schemaFilePath + "?");
     var loadSchemaFile, schemaData;

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ ilib-loctool-webos-appinfo-json is a plugin for the loctool that
 allows it to read and localize `appinfo.json` file. This plugin is optimized for webOS platform
 
 ## Release Notes
+v1.2.1
+* Fixed to load schema file correctly wherever plugin is installed
+
 v1.2.0
 * Create `x-json` type which will search first to get a translation. If it doesn't exist, it will search the `javascript` group tag as an alternative.
 * Fix not to create a file if there is no translation data.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-webos-appinfo-json",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "main": "AppinfoJsonFileType.js",
     "description": "appinfo.json file handler plugin for webOS platform loctool",
     "license": "Apache-2.0",


### PR DESCRIPTION
* Fixed code to load schema file correctly wherever a plugin is installed
* Added guard code to prevent error in `localizeText()`