### PR TITLE
Fix code not to generate manifest file when the content is empty

### DIFF
--- a/AppinfoJsonFile.js
+++ b/AppinfoJsonFile.js
@@ -340,7 +340,9 @@ AppinfoJsonFile.prototype.writeManifest = function(filePath) {
         logger.info("Writing out " + manifest.files[i]);
     }
     var manifestFilePath = path.join(filePath, "ilibmanifest.json");
-    fs.writeFileSync(manifestFilePath, JSON.stringify(manifest), 'utf8');
+    if (manifest.files.length > 0) {
+        fs.writeFileSync(manifestFilePath, JSON.stringify(manifest), 'utf8');
+    }
 }
 
 module.exports = AppinfoJsonFile;

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ ilib-loctool-webos-appinfo-json is a plugin for the loctool that
 allows it to read and localize `appinfo.json` file. This plugin is optimized for webOS platform
 
 ## Release Notes
+v1.2.3
+* Fixed not to generate `ilibmanifest.json` when the content is empty.
+
 v1.2.2
 * Fixed resource target path
 * Updated code to print log with log4js

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-webos-appinfo-json",
-    "version": "1.2.2",
+    "version": "1.2.3",
     "main": "AppinfoJsonFileType.js",
     "description": "appinfo.json file handler plugin for webOS platform loctool",
     "license": "Apache-2.0",


### PR DESCRIPTION
Fix code not to generate `ilibmanifest.json` file when the content is empty