### PR TITLE
Fixed not generating duplicated resources by comparing language default

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ ilib-loctool-webos-appinfo-json is a plugin for the loctool that
 allows it to read and localize `appinfo.json` file. This plugin is optimized for webOS platform
 
 ## Release Notes
+v1.5.0
+* Fixed not generating duplicated resources by comparing language default locale translation even if the locale follows the locale inheritance rule.
+
 v1.4.1
 * Added guard code to prevent errors when the common data path is incorrect.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-webos-appinfo-json",
-    "version": "1.4.1",
+    "version": "1.5.0",
     "main": "AppinfoJsonFileType.js",
     "description": "appinfo.json file handler plugin for webOS platform loctool",
     "license": "Apache-2.0",
@@ -47,11 +47,11 @@
         "node": ">=10.0.0"
     },
     "dependencies": {
-        "ilib": "^14.15.1"
+        "ilib": "^14.16.0"
     },
     "devDependencies": {
         "assertextras": "^1.1.0",
-        "loctool": "2.20.0",
+        "loctool": "2.20.2",
         "nodeunit": "^0.11.3"
     }
 }


### PR DESCRIPTION
* Fixed not generating duplicated resources by comparing language default locale translation even if the locale follows the locale inheritance rule.
 * Add new internal _getBaseTranslation() which is used in several places.
 * sample to check: https://github.com/iLib-js/ilib-loctool-samples/pull/43