### PR TITLE
Update some regarding manifest file generation

### DIFF
--- a/AppinfoJsonFile.js
+++ b/AppinfoJsonFile.js
@@ -1,7 +1,7 @@
 /*
  * AppinfoFile.js - plugin to extract resources from a appinfo.json code file
  *
- * Copyright (c) 2019-2020, 2022 JEDLSoft
+ * Copyright (c) 2019-2020, 2022-2023 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -448,12 +448,13 @@ AppinfoJsonFile.prototype.writeManifest = function(filePath) {
     }
 
     walk(filePath, "");
-    for (var i=0; i < manifest.files.length; i++) {
-        this.logger.info("Writing out", path.join(filePath, manifest.files[i]) + " to Manifest file");
-    }
     var manifestFilePath = path.join(filePath, "ilibmanifest.json");
-    if (manifest.files.length > 0) {
-        fs.writeFileSync(manifestFilePath, JSON.stringify(manifest), 'utf8');
+    if (!fs.existsSync(manifestFilePath) && manifest.files.length > 0) {
+        for (var i=0; i < manifest.files.length; i++) {
+            this.logger.info("Writing out", path.join(filePath, manifest.files[i]) + " to Manifest file");
+        }
+        manifest["l10n_timestamp"] = new Date().getTime().toString();
+        fs.writeFileSync(manifestFilePath, JSON.stringify(manifest, undefined, 4), 'utf8');
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ ilib-loctool-webos-appinfo-json is a plugin for the loctool that
 allows it to read and localize `appinfo.json` file. This plugin is optimized for webOS platform
 
 ## Release Notes
+v1.6.0
+* Add to timestampe in `ilibmanifest.json` file to support wee localization
+* Update to skip that writing `ilibmmanifest json` creation logic if it has already been done in another plugin.
+
 v1.5.0
 * Updated dependencies. (loctool: 2.20.2)
 * Fixed not generating duplicated resources by comparing language default locale translation even if the locale follows the locale inheritance rule.

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ allows it to read and localize `appinfo.json` file. This plugin is optimized for
 
 ## Release Notes
 v1.6.0
-* Add to timestampe in `ilibmanifest.json` file to support wee localization
-* Update to skip that writing `ilibmmanifest json` creation logic if it has already been done in another plugin.
+* Added to timestampe in `ilibmanifest.json` file to support wee localization.
+* Updated to skip writing `ilibmmanifest json` creation logic if it has already been done in another plugin.
 
 v1.5.0
 * Updated dependencies. (loctool: 2.20.2)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-webos-appinfo-json",
-    "version": "1.5.0",
+    "version": "1.6.0",
     "main": "AppinfoJsonFileType.js",
     "description": "appinfo.json file handler plugin for webOS platform loctool",
     "license": "Apache-2.0",
@@ -47,7 +47,7 @@
         "node": ">=10.0.0"
     },
     "dependencies": {
-        "ilib": "^14.16.0"
+        "ilib": "^14.17.0"
     },
     "devDependencies": {
         "assertextras": "^1.1.0",


### PR DESCRIPTION
* Added to timestamp in `ilibmanifest.json` file to support wee localization.
* Updated to skip writing `ilibmmanifest json` creation logic if it has already been done in another plugin.
*  Set to have more spaces in `ilibmanifest.json` file.