### PR TITLE
Fix to generate manifest file correctly even when a dummy file exists

### DIFF
--- a/AppinfoJsonFile.js
+++ b/AppinfoJsonFile.js
@@ -449,11 +449,17 @@ AppinfoJsonFile.prototype.writeManifest = function(filePath) {
 
     walk(filePath, "");
     var manifestFilePath = path.join(filePath, "ilibmanifest.json");
-    if (!fs.existsSync(manifestFilePath) && manifest.files.length > 0) {
+    var readManifest, data;
+    if (fs.existsSync(manifestFilePath)) {
+        readManifest = fs.readFileSync(manifestFilePath, {encoding:'utf8'});
+        data = JSON.parse(readManifest)
+    }
+    if ((!data || data["generated"] === undefined) && manifest.files.length > 0) {
         for (var i=0; i < manifest.files.length; i++) {
             this.logger.info("Writing out", path.join(filePath, manifest.files[i]) + " to Manifest file");
         }
         manifest["l10n_timestamp"] = new Date().getTime().toString();
+        manifest["generated"] = true;
         fs.writeFileSync(manifestFilePath, JSON.stringify(manifest, undefined, 4), 'utf8');
     }
 }

--- a/README.md
+++ b/README.md
@@ -4,9 +4,12 @@ ilib-loctool-webos-appinfo-json is a plugin for the loctool that
 allows it to read and localize `appinfo.json` file. This plugin is optimized for webOS platform
 
 ## Release Notes
+v1.6.1
+* Fixed to generate `ilibmanifest.json` file correctly even when a dummy file exists.
+
 v1.6.0
 * Added to timestampe in `ilibmanifest.json` file to support wee localization.
-* Updated to skip writing `ilibmmanifest json` creation logic if it has already been done in another plugin.
+* Updated to skip writing `ilibmanifest.json` creation logic if it has already been done in another plugin.
 
 v1.5.0
 * Updated dependencies. (loctool: 2.20.2)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-webos-appinfo-json",
-    "version": "1.6.0",
+    "version": "1.6.1",
     "main": "AppinfoJsonFileType.js",
     "description": "appinfo.json file handler plugin for webOS platform loctool",
     "license": "Apache-2.0",


### PR DESCRIPTION
Fix to generate manifest file correctly even when a dummy file exists