### PR TITLE
Updated not to load common data repeatedly if it's loaded from another plugin in a project.

### DIFF
--- a/AppinfoJsonFile.js
+++ b/AppinfoJsonFile.js
@@ -393,10 +393,11 @@ AppinfoJsonFile.prototype.localize = function(translations, locales) {
 
     if (this.commonPath) {
         if (!this.isloadCommonData) {
-            this._loadCommonXliff();
+            this._loadCommonXliff(translations);
             this.isloadCommonData = true;
+        } else {
+            this._manipulateCommondata(translations);
         }
-        this._addCommonDataTranslationSet(translations);
     }
     
     for (var i=0; i < locales.length; i++) {
@@ -412,7 +413,7 @@ AppinfoJsonFile.prototype.localize = function(translations, locales) {
     }
 };
 
-AppinfoJsonFile.prototype._addCommonDataTranslationSet = function(tsdata) {
+AppinfoJsonFile.prototype._manipulateCommondata = function(tsdata) {
     var prots = this.project.getRepository().getTranslationSet();
     var commonts = tsdata.getBy({project: "common"});
     if (commonts.length > 0){
@@ -424,7 +425,7 @@ AppinfoJsonFile.prototype._addCommonDataTranslationSet = function(tsdata) {
     }
 }
 
-AppinfoJsonFile.prototype._loadCommonXliff = function() {
+AppinfoJsonFile.prototype._loadCommonXliff = function(tsdata) {
     if (fs.existsSync(this.commonPath)){
         var list = fs.readdirSync(this.commonPath);
     }
@@ -438,6 +439,15 @@ AppinfoJsonFile.prototype._loadCommonXliff = function() {
             var pathName = path.join(this.commonPath, file);
             var data = fs.readFileSync(pathName, "utf-8");
             commonXliff.deserialize(data);
+            var resources = commonXliff.getResources();
+
+            if (resources.length > 0){
+                this.commonPrjName = resources[0].getProject();
+                this.commonPrjType = resources[0].getDataType();
+                resources.forEach(function(res){
+                    tsdata.add(res);
+                }.bind(this));
+            }
         }.bind(this));
     }
 };

--- a/AppinfoJsonFile.js
+++ b/AppinfoJsonFile.js
@@ -440,7 +440,7 @@ AppinfoJsonFile.prototype._loadCommonXliff = function(tsdata) {
             var data = fs.readFileSync(pathName, "utf-8");
             commonXliff.deserialize(data);
             var resources = commonXliff.getResources();
-
+            
             if (resources.length > 0){
                 this.commonPrjName = resources[0].getProject();
                 this.commonPrjType = resources[0].getDataType();

--- a/AppinfoJsonFile.js
+++ b/AppinfoJsonFile.js
@@ -387,7 +387,7 @@ AppinfoJsonFile.prototype.localizeText = function(translations, locale) {
 AppinfoJsonFile.prototype.localize = function(translations, locales) {
     // don't localize if there is no text
 
-    if ((typeof(translations) !== 'undefined') && (typeof(translations.getProjects()) !== 'undefined') && (translations.getProjects().includes("common"))) {
+    if ((typeof(translations) !== 'undefined') && (typeof(translations.getProjects()) !== 'undefined') && (translations.getProjects().indexOf("common") !== -1)) {
         this.isloadCommonData = true;
     }
 

--- a/AppinfoJsonFile.js
+++ b/AppinfoJsonFile.js
@@ -384,14 +384,23 @@ AppinfoJsonFile.prototype.localizeText = function(translations, locale) {
   * translations
   * @param {Array.<String>} locales array of locales to translate to
   */
-AppinfoJsonFile.prototype.localize = function(translations, locales) {
+AppinfoJsonFile.prototype.localize = function(translations, locales, num) {
     // don't localize if there is no text
 
-    if (this.commonPath && !this.isloadCommonData) {
-        this._loadCommonXliff(translations);
+    if ((typeof(translations) !== 'undefined') && (typeof(translations.getProjects()) !== 'undefined') && (translations.getProjects().includes("common"))) {
         this.isloadCommonData = true;
     }
 
+    if (this.commonPath) {
+        if (!this.isloadCommonData) {
+            this._loadCommonXliff(translations);
+            this.isloadCommonData = true;
+        } else {
+            console.log("_manipulateCommonData ", num);
+            this._manipulateCommonData(translations);
+        }
+    }
+    
     for (var i=0; i < locales.length; i++) {
        if (!this.project.isSourceLocale(locales[i])) {
             var translatedOutput = this.localizeText(translations, locales[i]);
@@ -404,6 +413,17 @@ AppinfoJsonFile.prototype.localize = function(translations, locales) {
        }
     }
 };
+AppinfoJsonFile.prototype._manipulateCommonData = function(tsdata) {
+    var prots = this.project.getRepository().getTranslationSet();
+    var commonts = tsdata.getBy({project:"common"});
+    if (commonts.length > 0){
+        this.commonPrjName = commonts[0].getProject();
+        this.commonPrjType = commonts[0].getDataType();
+        commonts.forEach(function(ts){
+            prots.add(ts);
+        }.bind(this));
+    }
+}
 
 AppinfoJsonFile.prototype._loadCommonXliff = function(tsdata) {
     if (fs.existsSync(this.commonPath)){

--- a/AppinfoJsonFile.js
+++ b/AppinfoJsonFile.js
@@ -396,7 +396,7 @@ AppinfoJsonFile.prototype.localize = function(translations, locales) {
             this._loadCommonXliff();
             this.isloadCommonData = true;
         }
-        this._addCommonDatatoTranSet(translations);
+        this._addCommonDataTranslationSet(translations);
     }
     
     for (var i=0; i < locales.length; i++) {
@@ -412,7 +412,7 @@ AppinfoJsonFile.prototype.localize = function(translations, locales) {
     }
 };
 
-AppinfoJsonFile.prototype._addCommonDatatoTranSet = function(tsdata) {
+AppinfoJsonFile.prototype._addCommonDataTranslationSet = function(tsdata) {
     var prots = this.project.getRepository().getTranslationSet();
     var commonts = tsdata.getBy({project: "common"});
     if (commonts.length > 0){

--- a/AppinfoJsonFile.js
+++ b/AppinfoJsonFile.js
@@ -396,7 +396,7 @@ AppinfoJsonFile.prototype.localize = function(translations, locales) {
             this._loadCommonXliff(translations);
             this.isloadCommonData = true;
         } else {
-            this._manipulateCommondata(translations);
+            this._addComonDatatoTranslationSet(translations);
         }
     }
     
@@ -413,7 +413,7 @@ AppinfoJsonFile.prototype.localize = function(translations, locales) {
     }
 };
 
-AppinfoJsonFile.prototype._manipulateCommondata = function(tsdata) {
+AppinfoJsonFile.prototype._addComonDatatoTranslationSet = function(tsdata) {
     var prots = this.project.getRepository().getTranslationSet();
     var commonts = tsdata.getBy({project: "common"});
     if (commonts.length > 0){

--- a/AppinfoJsonFile.js
+++ b/AppinfoJsonFile.js
@@ -384,7 +384,7 @@ AppinfoJsonFile.prototype.localizeText = function(translations, locale) {
   * translations
   * @param {Array.<String>} locales array of locales to translate to
   */
-AppinfoJsonFile.prototype.localize = function(translations, locales, num) {
+AppinfoJsonFile.prototype.localize = function(translations, locales) {
     // don't localize if there is no text
 
     if ((typeof(translations) !== 'undefined') && (typeof(translations.getProjects()) !== 'undefined') && (translations.getProjects().includes("common"))) {
@@ -393,12 +393,10 @@ AppinfoJsonFile.prototype.localize = function(translations, locales, num) {
 
     if (this.commonPath) {
         if (!this.isloadCommonData) {
-            this._loadCommonXliff(translations);
+            this._loadCommonXliff();
             this.isloadCommonData = true;
-        } else {
-            console.log("_manipulateCommonData ", num);
-            this._manipulateCommonData(translations);
         }
+        this._addCommonDatatoTranSet(translations);
     }
     
     for (var i=0; i < locales.length; i++) {
@@ -413,9 +411,10 @@ AppinfoJsonFile.prototype.localize = function(translations, locales, num) {
        }
     }
 };
-AppinfoJsonFile.prototype._manipulateCommonData = function(tsdata) {
+
+AppinfoJsonFile.prototype._addCommonDatatoTranSet = function(tsdata) {
     var prots = this.project.getRepository().getTranslationSet();
-    var commonts = tsdata.getBy({project:"common"});
+    var commonts = tsdata.getBy({project: "common"});
     if (commonts.length > 0){
         this.commonPrjName = commonts[0].getProject();
         this.commonPrjType = commonts[0].getDataType();
@@ -425,7 +424,7 @@ AppinfoJsonFile.prototype._manipulateCommonData = function(tsdata) {
     }
 }
 
-AppinfoJsonFile.prototype._loadCommonXliff = function(tsdata) {
+AppinfoJsonFile.prototype._loadCommonXliff = function() {
     if (fs.existsSync(this.commonPath)){
         var list = fs.readdirSync(this.commonPath);
     }
@@ -439,15 +438,6 @@ AppinfoJsonFile.prototype._loadCommonXliff = function(tsdata) {
             var pathName = path.join(this.commonPath, file);
             var data = fs.readFileSync(pathName, "utf-8");
             commonXliff.deserialize(data);
-            var resources = commonXliff.getResources();
-            
-            if (resources.length > 0){
-                this.commonPrjName = resources[0].getProject();
-                this.commonPrjType = resources[0].getDataType();
-                resources.forEach(function(res){
-                    tsdata.add(res);
-                }.bind(this));
-            }
         }.bind(this));
     }
 };

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ allows it to read and localize `appinfo.json` file. This plugin is optimized for
 v1.7.0
 * Added the `mappings` conguration which a mapping between file matchers and an object that gives info used to localize the files that match it.
 * Added feature not to do localization if the file is already located in localization directory.
-* Fixed not to load common data repeatedly if it's loaded from another plugin in a project.
+* Updated not to load common data repeatedly if it's loaded from another plugin in a project.
 
 v1.6.1
 * Fixed to generate `ilibmanifest.json` file correctly even when a dummy file exists.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ allows it to read and localize `appinfo.json` file. This plugin is optimized for
 v1.7.0
 * Added the `mappings` conguration which a mapping between file matchers and an object that gives info used to localize the files that match it.
 * Added feature not to do localization if the file is already located in localization directory.
+* Fixed not to load common data repeatedly if it's loaded from another plugin in a project.
 
 v1.6.1
 * Fixed to generate `ilibmanifest.json` file correctly even when a dummy file exists.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ v1.7.0
 * Added the `mappings` conguration which a mapping between file matchers and an object that gives info used to localize the files that match it.
 * Added feature not to do localization if the file is already located in localization directory.
 * Fixed not to load common data repeatedly if it's loaded from another plugin in a project.
-* Improved of performance by separating the part of reading common data file  and the part of saving  data in translationset
 
 v1.6.1
 * Fixed to generate `ilibmanifest.json` file correctly even when a dummy file exists.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ v1.7.0
 * Added the `mappings` conguration which a mapping between file matchers and an object that gives info used to localize the files that match it.
 * Added feature not to do localization if the file is already located in localization directory.
 * Fixed not to load common data repeatedly if it's loaded from another plugin in a project.
+* Improved of performance by separating the part of reading common data file  and the part of saving  data in translationset
 
 v1.6.1
 * Fixed to generate `ilibmanifest.json` file correctly even when a dummy file exists.


### PR DESCRIPTION
* Updated not to load common data repeatedly if it's loaded from another plugin in a project.
   * the common data files are loaded for each appinfon json file localization. It means, cpstubs app case in webOS , multiple times common data file loading has happened. and it looks like it s a hang in this part. (never-ending localization..)
   * Implemented not to load common data files if it's already loaded. only add data to the translation set.